### PR TITLE
Ensure rmdir fails when directory has children

### DIFF
--- a/fs/src/fs.c
+++ b/fs/src/fs.c
@@ -151,6 +151,8 @@ int cmd_rmdir(char *name) {
     for (int i = 0; i < cwd->child_count; i++) {
         vfile *c = cwd->children[i];
         if (c->type == T_DIR && strcmp(c->name, name) == 0) {
+            if (c->child_count != 0)
+                return E_ERROR;
             remove_child(cwd, i);
             return E_SUCCESS;
         }


### PR DESCRIPTION
## Summary
- verify a directory is empty before removing it
- return `E_ERROR` when `cmd_rmdir` is invoked on a non-empty directory

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68406d76eda8832ab16c38289d6c3eab