### PR TITLE
Fix header guard typo

### DIFF
--- a/fs/include/common.h
+++ b/fs/include/common.h
@@ -1,5 +1,5 @@
-#ifndef __COMMAN_H__
-#define __COMMAN_H__
+#ifndef __COMMON_H__
+#define __COMMON_H__
 
 typedef unsigned char uchar;
 typedef unsigned short ushort;


### PR DESCRIPTION
## Summary
- fix misspelled include guard in `common.h`

## Testing
- `make test` *(fails: test_cmd_rmdir_with_files)*

------
https://chatgpt.com/codex/tasks/task_e_68406d77de84832a9d878953432aa39d