### PR TITLE
Improve server command parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# FileSystem
+
+This project provides a small in-memory file system.  The `fs` directory
+contains both a local command line program and a TCP based server.
+
+## Building
+
+Run `make -C fs` to compile the binaries and `make test` to execute the unit
+suite.
+
+## Network usage
+
+`./fs/FS` starts the file system server listening on port `666`.  The
+`./fs/FC` utility connects to this server and sends commands.  Commands are the
+same as those supported by `FS_local`.  A typical session looks like:
+
+```sh
+$ ./fs/FS &
+$ ./fs/FC 666
+login 1
+f
+mk foo 0b1111
+ls
+e
+```
+
+The client prints any responses from the server and exits when it receives
+`Bye!`.

--- a/fs/src/server.c
+++ b/fs/src/server.c
@@ -25,7 +25,11 @@ static int handle_f(tcp_buffer *wb, char *args, int len) {
 }
 
 static int handle_mk(tcp_buffer *wb, char *args, int len) {
-    if (cmd_mk(NULL, 0) == E_SUCCESS) {
+    char *name = strtok(args, " ");
+    char *mode_str = strtok(NULL, " ");
+    short mode = 0;
+    if (mode_str) mode = (short)strtol(mode_str, NULL, 0);
+    if (name && cmd_mk(name, mode) == E_SUCCESS) {
         reply_with_yes(wb, NULL, 0);
     } else {
         reply_with_no(wb, NULL, 0);
@@ -34,7 +38,11 @@ static int handle_mk(tcp_buffer *wb, char *args, int len) {
 }
 
 static int handle_mkdir(tcp_buffer *wb, char *args, int len) {
-    if (cmd_mkdir(NULL, 0) == E_SUCCESS) {
+    char *name = strtok(args, " ");
+    char *mode_str = strtok(NULL, " ");
+    short mode = 0;
+    if (mode_str) mode = (short)strtol(mode_str, NULL, 0);
+    if (name && cmd_mkdir(name, mode) == E_SUCCESS) {
         reply_with_yes(wb, NULL, 0);
     } else {
         reply_with_no(wb, NULL, 0);
@@ -43,7 +51,8 @@ static int handle_mkdir(tcp_buffer *wb, char *args, int len) {
 }
 
 static int handle_rm(tcp_buffer *wb, char *args, int len) {
-    if (cmd_rm(NULL) == E_SUCCESS) {
+    char *name = strtok(args, " ");
+    if (name && cmd_rm(name) == E_SUCCESS) {
         reply_with_yes(wb, NULL, 0);
     } else {
         reply_with_no(wb, NULL, 0);
@@ -52,7 +61,8 @@ static int handle_rm(tcp_buffer *wb, char *args, int len) {
 }
 
 static int handle_cd(tcp_buffer *wb, char *args, int len) {
-    if (cmd_cd(NULL) == E_SUCCESS) {
+    char *name = strtok(args, " ");
+    if (name && cmd_cd(name) == E_SUCCESS) {
         reply_with_yes(wb, NULL, 0);
     } else {
         reply_with_no(wb, NULL, 0);
@@ -61,7 +71,8 @@ static int handle_cd(tcp_buffer *wb, char *args, int len) {
 }
 
 static int handle_rmdir(tcp_buffer *wb, char *args, int len) {
-    if (cmd_rmdir(NULL) == E_SUCCESS) {
+    char *name = strtok(args, " ");
+    if (name && cmd_rmdir(name) == E_SUCCESS) {
         reply_with_yes(wb, NULL, 0);
     } else {
         reply_with_no(wb, NULL, 0);
@@ -82,9 +93,11 @@ static int handle_ls(tcp_buffer *wb, char *args, int len) {
 }
 
 static int handle_cat(tcp_buffer *wb, char *args, int len) {
+    char *name = strtok(args, " ");
+
     uchar *buf = NULL;
     uint l;
-    if (cmd_cat(NULL, &buf, &l) == E_SUCCESS) {
+    if (name && cmd_cat(name, &buf, &l) == E_SUCCESS) {
         reply_with_yes(wb, (char *)buf, l);
         free(buf);
     } else {
@@ -94,7 +107,13 @@ static int handle_cat(tcp_buffer *wb, char *args, int len) {
 }
 
 static int handle_w(tcp_buffer *wb, char *args, int len) {
-    if (cmd_w(NULL, 0, NULL) == E_SUCCESS) {
+    char *name = strtok(args, " ");
+    char *len_str = strtok(NULL, " ");
+    uint l = 0;
+    if (len_str) l = strtoul(len_str, NULL, 0);
+    char *data = strtok(NULL, "");
+    if (!data) data = "";
+    if (name && cmd_w(name, l, data) == E_SUCCESS) {
         reply_with_yes(wb, NULL, 0);
     } else {
         reply_with_no(wb, NULL, 0);
@@ -103,7 +122,15 @@ static int handle_w(tcp_buffer *wb, char *args, int len) {
 }
 
 static int handle_i(tcp_buffer *wb, char *args, int len) {
-    if (cmd_i(NULL, 0, 0, NULL) == E_SUCCESS) {
+    char *name = strtok(args, " ");
+    char *pos_str = strtok(NULL, " ");
+    char *len_str = strtok(NULL, " ");
+    uint pos = 0, l = 0;
+    if (pos_str) pos = strtoul(pos_str, NULL, 0);
+    if (len_str) l = strtoul(len_str, NULL, 0);
+    char *data = strtok(NULL, "");
+    if (!data) data = "";
+    if (name && cmd_i(name, pos, l, data) == E_SUCCESS) {
         reply_with_yes(wb, NULL, 0);
     } else {
         reply_with_no(wb, NULL, 0);
@@ -112,7 +139,13 @@ static int handle_i(tcp_buffer *wb, char *args, int len) {
 }
 
 static int handle_d(tcp_buffer *wb, char *args, int len) {
-    if (cmd_d(NULL, 0, 0) == E_SUCCESS) {
+    char *name = strtok(args, " ");
+    char *pos_str = strtok(NULL, " ");
+    char *len_str = strtok(NULL, " ");
+    uint pos = 0, l = 0;
+    if (pos_str) pos = strtoul(pos_str, NULL, 0);
+    if (len_str) l = strtoul(len_str, NULL, 0);
+    if (name && cmd_d(name, pos, l) == E_SUCCESS) {
         reply_with_yes(wb, NULL, 0);
     } else {
         reply_with_no(wb, NULL, 0);
@@ -127,7 +160,10 @@ static int handle_e(tcp_buffer *wb, char *args, int len) {
 }
 
 static int handle_login(tcp_buffer *wb, char *args, int len) {
-    if (cmd_login(0) == E_SUCCESS) {
+    char *uid_str = strtok(args, " ");
+    int uid = 0;
+    if (uid_str) uid = atoi(uid_str);
+    if (cmd_login(uid) == E_SUCCESS) {
         reply_with_yes(wb, NULL, 0);
     } else {
         reply_with_no(wb, NULL, 0);


### PR DESCRIPTION
## Summary
- parse server arguments the same way as the local interface
- add a README describing how to run the network server and client

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840795ccf70832a8c9a0886086098f6