### PR TITLE
Ensure cmd_cat outputs null-terminated buffer

### DIFF
--- a/fs/src/fs.c
+++ b/fs/src/fs.c
@@ -180,6 +180,7 @@ int cmd_cat(char *name, uchar **buf, uint *len) {
     *buf = malloc(*len + 1);
     if (!*buf && *len) return E_ERROR;
     memcpy(*buf, c->data, *len);
+    (*buf)[*len] = '\0';
     return E_SUCCESS;
 }
 


### PR DESCRIPTION
## Summary
- add missing null terminator when reading file data in `cmd_cat`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68407db122ac832a8fabe3fcfcc1608e