### PR TITLE
Fix mkdir reply message

### DIFF
--- a/fs/src/main.c
+++ b/fs/src/main.c
@@ -54,7 +54,7 @@ int handle_mkdir(char *args) {
     if (name && cmd_mkdir(name, mode) == E_SUCCESS) {
         ReplyYes();
     } else {
-        ReplyNo("Failed to create file");
+        ReplyNo("Failed to create directory");
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- correct `handle_mkdir` failure message

## Testing
- `make -C fs`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68407de89608832a8c171aea801ff5d4