### PR TITLE
Fix heap buffer overflow in ls server response

### DIFF
--- a/fs/src/server.c
+++ b/fs/src/server.c
@@ -88,7 +88,8 @@ static int handle_ls(tcp_buffer *wb, char *args, int len) {
         for (int i = 0; i < n; i++) total += 2 + strlen(entries[i].name) + 1;
         char *buf = NULL;
         if (total > 0) {
-            buf = malloc(total);
+            /* +1 to accommodate the trailing null byte from sprintf */
+            buf = malloc(total + 1);
             char *p = buf;
             for (int i = 0; i < n; i++) {
                 char type = entries[i].type == T_DIR ? 'D' : 'F';


### PR DESCRIPTION
## Summary
- fix off-by-one allocation in `handle_ls` response buffer

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68417fb2aab0832aaeaf1f14c978c37d