### PR TITLE
Fix ls buffer overflow

### DIFF
--- a/fs/src/fs.c
+++ b/fs/src/fs.c
@@ -28,6 +28,7 @@ static vfile *create_vfile(const char *name, short mode, short type, vfile *pare
     vfile *vf = calloc(1, sizeof(vfile));
     if (!vf) return NULL;
     strncpy(vf->name, name, MAXNAME - 1);
+    vf->name[MAXNAME - 1] = '\0';
     vf->mode = mode;
     vf->type = type;
     vf->parent = parent;

--- a/fs/src/server.c
+++ b/fs/src/server.c
@@ -93,7 +93,14 @@ static int handle_ls(tcp_buffer *wb, char *args, int len) {
             char *p = buf;
             for (int i = 0; i < n; i++) {
                 char type = entries[i].type == T_DIR ? 'D' : 'F';
-                int w = sprintf(p, "%c %s\n", type, entries[i].name);
+                size_t left = total + 1 - (p - buf);
+                int w = snprintf(p, left, "%c %s\n", type, entries[i].name);
+                if (w < 0 || (size_t)w >= left) {
+                    free(buf);
+                    free(entries);
+                    reply_with_no(wb, NULL, 0);
+                    return 0;
+                }
                 p += w;
             }
         }


### PR DESCRIPTION
## Summary
- ensure vfile names are always null terminated
- guard ls output formatting with snprintf

## Testing
- `make -C fs`
- `./test_fs`

------
https://chatgpt.com/codex/tasks/task_e_6841816a4bfc832aade2a99c39c6e360